### PR TITLE
Fix ondd parameters in it's init script

### DIFF
--- a/ondd/S90ondd
+++ b/ondd/S90ondd
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 PID_FILE=/var/run/ondd.pid
+SDR_SOCKET_PATH=/var/run/ondd.data
 CACHE_PATH=%CACHEDIR%
 MAIN_STORAGE=%INTERNALDIR%
 EXT_STORAGE=%EXTERNALDIR%
 ONDD_GROUP=%GROUP%
 ONDD_TIMEOUT_HANDLER=/usr/sbin/ontimeout
-ONDD_SDR_TIMEOUT=60  # seconds
 ONDD_EXTRA_ARGS=
 
 if [ -x "$ONDD_TIMEOUT_HANDLER" ]; then
-  ONDD_EXTRA_ARGS="--sdr-timeout-handler $ONDD_TIMEOUT_HANDLER --sdr-timeout $ONDD_SDR_TIMEOUT"
+  ONDD_EXTRA_ARGS="--sdr-timeout-handler $ONDD_TIMEOUT_HANDLER"
 fi
 
 start() {
@@ -28,7 +28,7 @@ start() {
     output_path=$MAIN_STORAGE
   fi
 
-  ondd_args="-d --pid-file $PID_FILE -c $CACHE_PATH -o $output_path $ONDD_EXTRA_ARGS"
+  ondd_args="-d --pid-file $PID_FILE -c $CACHE_PATH -o $output_path -D $SDR_SOCKET_PATH $ONDD_EXTRA_ARGS"
 
   printf "Starting ondd: "
   start-stop-daemon -S -q -p $PID_FILE --exec /usr/sbin/ondd -- $ondd_args


### PR DESCRIPTION
The `--sdr-timeout` parameter was dropped in latest build of ondd, and `-D` was missing from the init script which specified the socket to which sdr100 is sending the packets.
