### PR TITLE
Fix python-librarian-svm makefile

### DIFF
--- a/python-librarian-svm/python-librarian-svm.mk
+++ b/python-librarian-svm/python-librarian-svm.mk
@@ -11,8 +11,8 @@ PYTHON_LIBRARIAN_SVM_LICENSE_FILES = COPYING
 PYTHON_LIBRARIAN_SVM_SETUP_TYPE = setuptools
 
 define PYTHON_LIBRARIAN_SVM_INSTALL_CONF
-	$(INSTALL) -Dm644 $(call epkgdir,python-librarian-sdr)/sdr.ini \
-		$(TARGET_DIR)/etc/librarian.d/sdr.ini
+	$(INSTALL) -Dm644 $(call epkgdir,python-librarian-svm)/svm.ini \
+		$(TARGET_DIR)/etc/librarian.d/svm.ini
 endef
 
 ifeq ($(BR2_PACKAGE_PYTHON_LIBRARIAN_SVM),y)


### PR DESCRIPTION
Due to copy-hasting, the function that copies the configuration ini of
the app into the desired location hadn't been adjusted and it references
an ini file from another app.
