### PR TITLE
Add python-librarian-remote package

### DIFF
--- a/python-librarian-remote/Config.in
+++ b/python-librarian-remote/Config.in
@@ -1,0 +1,10 @@
+config BR2_PACKAGE_PYTHON_LIBRARIAN_REMOTE
+	bool "python-librarian-remote"
+	depends on (BR2_PACKAGE_PYTHON || BR2_PACKAGE_PYTHON3) && BR2_PACKAGE_PYTHON_LIBRARIAN
+	help
+	  Remote SSH access setup tool
+
+	  https://github.com/Outernet-Project/librarian-remote/
+
+comment "python-librarian-remote depends on python-librarian"
+	depends on !BR2_PACKAGE_PYTHON_LIBRARIAN

--- a/python-librarian-remote/python-librarian-remote.mk
+++ b/python-librarian-remote/python-librarian-remote.mk
@@ -1,0 +1,23 @@
+################################################################################
+#
+# python-librarian-remote
+#
+################################################################################
+
+PYTHON_LIBRARIAN_REMOTE_VERSION = 1c82ae47ccf066150ee9f0af793b6a797d11f388
+PYTHON_LIBRARIAN_REMOTE_SITE = $(call github,Outernet-Project,librarian-remote,$(PYTHON_LIBRARIAN_REMOTE_VERSION))
+PYTHON_LIBRARIAN_REMOTE_LICENSE = GPLv3+
+PYTHON_LIBRARIAN_REMOTE_LICENSE_FILES = COPYING
+PYTHON_LIBRARIAN_REMOTE_SETUP_TYPE = setuptools
+
+define PYTHON_LIBRARIAN_REMOTE_INSTALL_CONF
+	$(INSTALL) -Dm644 $(call epkgdir,python-librarian-remote)/remote.ini \
+		$(TARGET_DIR)/etc/librarian.d/remote.ini
+endef
+
+ifeq ($(BR2_PACKAGE_PYTHON_LIBRARIAN_REMOTE),y)
+LIBRARIAN_COMPONENTS += librarian_REMOTE
+TARGET_FINALIZE_HOOKS += PYTHON_LIBRARIAN_REMOTE_INSTALL_CONF
+endif
+
+$(eval $(python-package))

--- a/python-librarian-remote/remote.ini
+++ b/python-librarian-remote/remote.ini
@@ -1,0 +1,3 @@
+[remote]
+
+file = /mnt/conf/REMOTE


### PR DESCRIPTION
python-librarian-remote allows the management of remote SSH configration
through a dashboard plugin.
