### PR TITLE
Adjust helptext and config template for python-librarian-netinterfaces

### DIFF
--- a/python-librarian-netinterfaces/Config.in
+++ b/python-librarian-netinterfaces/Config.in
@@ -11,11 +11,11 @@ menuconfig BR2_PACKAGE_PYTHON_LIBRARIAN_NETINTERFACES
 if BR2_PACKAGE_PYTHON_LIBRARIAN_NETINTERFACES
 
 config BR2_PYTHON_LIBRARIAN_NETINTERFACES_AP_RESTART_CMD
-	string "Command to restart hostapd"
+	string "Command to restart network stack"
 	default "reboot"
 	help
 	  Command that will be triggered by
-	  librarian-netinterfaces to restart hostad
+	  librarian-netinterfaces to restart network stack
 	  and apply its settings.
 
 endif # BR2_PACKAGE_PYTHON_LIBRARIAN_NETINTERFACES

--- a/python-librarian-netinterfaces/netinterfaces.ini
+++ b/python-librarian-netinterfaces/netinterfaces.ini
@@ -1,3 +1,4 @@
 [wireless]
 
-restart_command = %RESTART_CMD%
+restart_commands =
+    %RESTART_CMD%


### PR DESCRIPTION
Netinterfaces now restarts the whole network stack instead of just
hostapd, and the restart command variable in the config file is
expecting a sequence of commands instead of one single command.
